### PR TITLE
Package not being added to 'client' architecture

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,11 +8,11 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom("METEOR@0.9.3");
   api.use("jquery");
-  api.addFiles('papa-parse.js', ['client']);
+  api.addFiles('papa-parse.js', 'client');
 });
 
 Package.onTest(function(api) {
   api.use('tinytest');
   api.use('harrison:papa-parse');
-  api.addFiles('papa-parse-tests.js', ['client']);
+  api.addFiles('papa-parse-tests.js', 'client');
 });


### PR DESCRIPTION
As per http://docs.meteor.com/#/full/pack_addFiles, second argument to api.addFiles() should be a String. 

```
api.addFiles(filename, [architecture])
```

I think that the brackets in the above-mentioned documentation denote that "architecture" is an optional argument, not an Array, and this is the possible source of confusion.
